### PR TITLE
[nfthack] Pay with NFTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ out
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+.vscode
 
 # yarn v2
 .yarn/cache

--- a/development.html
+++ b/development.html
@@ -33,38 +33,22 @@
         </div>
         <div class="form-group pt-1">
           <label for="senderAddress">Sender</label>
-          (<a id="nftSelector" href="#">View</a>)
-          <script>
-            var button = document.getElementById("nftSelector");
-            button.addEventListener("click",function(e){
+          <input class="form-control text-center" id="senderAddress" aria-describedby="senderAddressDesc" placeholder="0x317D875cA3B9f8d14f960486C0d1D1913be74e90" value="0x317D875cA3B9f8d14f960486C0d1D1913be74e90">
+          <label style="margin-top: 8px;" for="selectedNftToken">Selected NFT</label>
+          <input disabled class="form-control text-center" id="selectedNftToken" placeholder="" value="">
+          <small id="senderAddressDesc" class="form-text text-muted">Which NFT do you want to sell?</small>
+        </div>
+        
+        <button id="payWithNftButton" class="btn-lg mt-2">Pay with NFT</button>
+        <script>
+          var button = document.getElementById("payWithNftButton");
+          button.addEventListener("click",function(e){
               DePayWidgets.Nft.Selector({
                 sender: document.getElementById("senderAddress").value,
               }, function(tokenId){
                 document.getElementById("selectedNftToken").value = tokenId;
               });
             });
-          </script>  
-          <input class="form-control text-center" id="senderAddress" aria-describedby="senderAddressDesc" placeholder="0x317D875cA3B9f8d14f960486C0d1D1913be74e90" value="0x317D875cA3B9f8d14f960486C0d1D1913be74e90">
-          <label style="margin-top: 8px;" for="selectedNftToken">Selected NFT</label>
-          <input disabled class="form-control text-center" id="selectedNftToken" placeholder="" value="">
-          <small id="senderAddressDesc" class="form-text text-muted">Which NFT do you want to sell?</small>
-        </div>
-        <div class="form-group pt-1">
-          <label for="paymentReceiverInput">Receiver</label>
-          <input class="form-control text-center" id="paymentReceiverInput" aria-describedby="paymentReceiver" placeholder="0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02" value="0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02">
-          <small id="paymentReceiver" class="form-text text-muted">Which address should receive the payment?</small>
-        </div>
-        
-        <button id="payButton" class="btn-lg mt-2">Pay</button>
-        <script>
-          var button = document.getElementById("payButton");
-          button.addEventListener("click",function(e){
-            DePayWidgets.Payment({
-              amount: document.getElementById("paymentAmountInput").value,
-              token: document.getElementById("paymentTokenInput").value,
-              receiver: document.getElementById("paymentReceiverInput").value
-            });
-          });
         </script>
       </div>
       <div class="col-4"></div>

--- a/development.html
+++ b/development.html
@@ -21,6 +21,56 @@
   </head>
   <body style="text-align: center;">
     
+    <div class="container pb-4"><!-- NFT -->
+      <div class="row">
+      <div class="col-4"></div>
+      <div class="col-4">
+        <h2 class="pt-5">NFT</h2>
+        <div class="form-group pt-3">
+          <label for="paymentAmountInput">Amount</label>
+          <input class="form-control text-center" id="paymentAmountInput" aria-describedby="paymentAmount" placeholder="20" value="20">
+          <small id="paymentAmount" class="form-text text-muted">How much do you want to receive?</small>
+        </div>
+        <div class="form-group pt-1">
+          <label for="senderAddress">Sender</label>
+          (<a id="nftSelector" href="#">View</a>)
+          <script>
+            var button = document.getElementById("nftSelector");
+            button.addEventListener("click",function(e){
+              DePayWidgets.Nft.Selector({
+                sender: document.getElementById("senderAddress").value,
+              }, function(tokenId){
+                document.getElementById("selectedNftToken").value = tokenId;
+              });
+            });
+          </script>  
+          <input class="form-control text-center" id="senderAddress" aria-describedby="senderAddressDesc" placeholder="0x317D875cA3B9f8d14f960486C0d1D1913be74e90" value="0x317D875cA3B9f8d14f960486C0d1D1913be74e90">
+          <label style="margin-top: 8px;" for="selectedNftToken">Selected NFT</label>
+          <input disabled class="form-control text-center" id="selectedNftToken" placeholder="" value="">
+          <small id="senderAddressDesc" class="form-text text-muted">Which NFT do you want to sell?</small>
+        </div>
+        <div class="form-group pt-1">
+          <label for="paymentReceiverInput">Receiver</label>
+          <input class="form-control text-center" id="paymentReceiverInput" aria-describedby="paymentReceiver" placeholder="0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02" value="0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02">
+          <small id="paymentReceiver" class="form-text text-muted">Which address should receive the payment?</small>
+        </div>
+        
+        <button id="payButton" class="btn-lg mt-2">Pay</button>
+        <script>
+          var button = document.getElementById("payButton");
+          button.addEventListener("click",function(e){
+            DePayWidgets.Payment({
+              amount: document.getElementById("paymentAmountInput").value,
+              token: document.getElementById("paymentTokenInput").value,
+              receiver: document.getElementById("paymentReceiverInput").value
+            });
+          });
+        </script>
+      </div>
+      <div class="col-4"></div>
+    </div><!-- NFT -->
+    
+    
     <div class="container pb-4"><!-- Payment -->
       <div class="row">
       <div class="col-4"></div>

--- a/src/Nft.jsx
+++ b/src/Nft.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import ShadowContainer from './utils/ShadowContainer'
+import NftSelectorDialogue from './dialogs/NftSelectorDialogue'
+
+export function Selector(options, callback) {
+  const [shadowContainer, closeContainer] = ShadowContainer()
+  ReactDOM.render(
+    <NftSelectorDialogue
+      closeContainer={closeContainer}
+      sender={options.sender}
+      callback={callback}
+    />,
+    shadowContainer,
+  )
+}
+
+export default {
+  Selector,
+}

--- a/src/dialogs/NftSelectorDialogue.jsx
+++ b/src/dialogs/NftSelectorDialogue.jsx
@@ -1,0 +1,31 @@
+import CloseDialogComponent from '../components/CloseDialogComponent'
+import Fuse from 'fuse.js'
+import GoBackDialogComponent from '../components/GoBackDialogComponent'
+import ImportToken from '../utils/ImportToken'
+import PropTypes from 'prop-types'
+import React from 'react'
+import TokenIconComponent from '../components/TokenIconComponent'
+import TokenList from '../utils/TokenList'
+import { ethers } from 'ethers'
+
+class NftSelectorDialogue extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  async componentDidMount() {
+    const { sender } = this.props
+    const fetchAssetsResponse = await fetch(
+      `https://api.opensea.io/api/v1/assets?owner=${sender}&order_direction=desc&offset=0&limit=20`,
+    )
+
+    const assets = await fetchAssetsResponse.json()
+    console.log('assets', assets)
+  }
+
+  render() {
+    return <div>NFT Selector 2021</div>
+  }
+}
+
+export default NftSelectorDialogue

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,9 @@
-import Donation from './Donation';
-import Payment from './Payment';
-import Sale from './Sale';
-import Selector from './Selector';
-import Swap from './Swap';
-import { ethers } from 'ethers';
+import Donation from './Donation'
+import Payment from './Payment'
+import Nft from './Nft'
+import Sale from './Sale'
+import Selector from './Selector'
+import Swap from './Swap'
+import { ethers } from 'ethers'
 
-export {
-  ethers,
-  Donation,
-  Payment,
-  Sale,
-  Selector,
-  Swap,
-}
+export { ethers, Donation, Payment, Nft, Sale, Selector, Swap }


### PR DESCRIPTION
Work in progress for NFTHack.

Current sets up a basic widget that renders a react component that calls OpenSea /assets given the sender's address. Right now, not doing anything with the response, but the goal would be to render metadata in a scrollable list to allow the user to select it. 

The updates to `development.html` aren't super precise, just copy-pasted the `Payment` section. Will need to flesh out further what the interaction needs to feel like. One idea is `Pay with NFT` button that opens a scrollable view that lets you select a valid NFT. 

Todo: 
- [ ] Figure out if sender's address can be passed in a different way rather than input field (should be through an existing provider component since that value is derived from the connected wallet?) 
- [ ] Figure out additional filtering on the assets to determine which are usable
  - Need to do something with existing buy orders if I recall
- [ ] Rich rendering of NFTs
- [ ] Pass the amount to be paid and use that to determine ideal NFT? 
- [ ] Document `Depay.Nft.*`


### Expected behaviour (2021-03-19 10:40 PM Eastern)

Clicking `Pay with NFT` opens up a dialogue (which doesn't render anything useful), but console logs assets under the sender address: 

![Screen Shot 2021-03-19 at 10 32 25 PM](https://user-images.githubusercontent.com/5963656/111856740-4aeec000-8903-11eb-9b46-ab20cc4302d2.png)

![Screen Shot 2021-03-19 at 10 32 55 PM](https://user-images.githubusercontent.com/5963656/111856742-4fb37400-8903-11eb-9502-306238b32cf5.png)
