### PR TITLE
Payment value loss safeguard

### DIFF
--- a/cypress/integration/Donation/amount.js
+++ b/cypress/integration/Donation/amount.js
@@ -368,7 +368,7 @@ describe('change Donation amount', () => {
           api: exchange.contracts.router.api,
           method: 'getAmountsIn',
           params: [ethers.utils.parseUnits('18', 18), [DAI, WETH, DEPAY]],
-          return: [ethers.utils.parseUnits('18', 18), ethers.utils.parseUnits('0.05', 18), ethers.utils.parseUnits('11.6', 18)]
+          return: [ethers.utils.parseUnits('18', 18), ethers.utils.parseUnits('0.05', 18), ethers.utils.parseUnits('18', 18)]
         }
       })
       mockAmountsOut({
@@ -380,7 +380,7 @@ describe('change Donation amount', () => {
         amountsOut: [
           ethers.utils.parseUnits('18', 18),
           ethers.utils.parseUnits('0.05', 18),
-          ethers.utils.parseUnits('11.6', 18)
+          ethers.utils.parseUnits('18', 18)
         ]
       })
 

--- a/cypress/integration/Payment/amount.js
+++ b/cypress/integration/Payment/amount.js
@@ -368,7 +368,7 @@ describe('change Payment amount', () => {
           api: exchange.contracts.router.api,
           method: 'getAmountsIn',
           params: [ethers.utils.parseUnits('18', 18), [DAI, WETH, DEPAY]],
-          return: [ethers.utils.parseUnits('18', 18), ethers.utils.parseUnits('0.05', 18), ethers.utils.parseUnits('11.6', 18)]
+          return: [ethers.utils.parseUnits('18', 18), ethers.utils.parseUnits('0.05', 18), ethers.utils.parseUnits('18', 18)]
         }
       })
       mockAmountsOut({
@@ -380,7 +380,7 @@ describe('change Payment amount', () => {
         amountsOut: [
           ethers.utils.parseUnits('18', 18),
           ethers.utils.parseUnits('0.05', 18),
-          ethers.utils.parseUnits('11.6', 18)
+          ethers.utils.parseUnits('18', 18)
         ]
       })
 

--- a/cypress/integration/Payment/payment-value-loss-safeguard.js
+++ b/cypress/integration/Payment/payment-value-loss-safeguard.js
@@ -171,7 +171,9 @@ describe('change Payment amount', () => {
           cy.get('.ReactShadowDOMOutsideContainer').shadow().find('input').type('10', { force: true })
           cy.get('.ReactShadowDOMOutsideContainer').shadow().contains('.ButtonPrimary', 'Done').click()
           cy.get('.ReactShadowDOMOutsideContainer').shadow().contains('.Alert', "Payment token would lose 36% of it's value!").should('exist')
-          cy.get('.ReactShadowDOMOutsideContainer').shadow().contains('.ButtonPrimary.disabled').should('exist')
+          cy.wait(1000).then(()=>{
+            cy.get('.ButtonPrimary.disabled', { includeShadowDom: true }).should('exist')
+          })
         })
       })
     })

--- a/cypress/integration/Payment/payment-value-loss-safeguard.js
+++ b/cypress/integration/Payment/payment-value-loss-safeguard.js
@@ -1,0 +1,180 @@
+import closeWidget from '../../../tests/helpers/closeWidget'
+import DePayWidgets from '../../../src'
+import fetchMock from 'fetch-mock'
+import mockBasics from '../../../tests/mocks/basics'
+import mockAmountsOut from '../../../tests/mocks/amountsOut'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { CONSTANTS } from '@depay/web3-constants'
+import { ethers } from 'ethers'
+import { mock, confirm, resetMocks, anything } from '@depay/web3-mock'
+import { resetCache, provider } from '@depay/web3-client'
+import { routers, plugins } from '@depay/web3-payments'
+import { Token } from '@depay/web3-tokens'
+
+describe('change Payment amount', () => {
+
+  const blockchain = 'ethereum'
+  const accounts = ['0xd8da6bf26964af9d7eed9e03e53415d37aa96045']
+  beforeEach(resetMocks)
+  beforeEach(resetCache)
+  beforeEach(()=>fetchMock.restore())
+  beforeEach(()=>mock({ blockchain, accounts: { return: accounts } }))
+  afterEach(closeWidget)
+
+  let DEPAY = '0xa0bEd124a09ac2Bd941b10349d8d224fe3c955eb'
+  let DAI = CONSTANTS[blockchain].USD
+  let ETH = CONSTANTS[blockchain].NATIVE
+  let WETH = CONSTANTS[blockchain].WRAPPED
+  let WRAPPED_AmountInBN
+  let TOKEN_A_AmountBN
+  let TOKEN_B_AmountBN
+  let toAddress = '0x4e260bB2b25EC6F3A59B478fCDe5eD5B8D783B02'
+  let amount = 1.8
+  let exchange
+  let defaultArguments = {
+    accept:[{
+      blockchain,
+      token: DEPAY,
+      receiver: toAddress
+    }]
+  }
+
+  beforeEach(()=>{
+    ({
+      WRAPPED_AmountInBN,
+      TOKEN_A_AmountBN,
+      TOKEN_B_AmountBN,
+      exchange
+    } = mockBasics({
+      provider: provider(blockchain),
+      blockchain,
+      fromAddress: accounts[0],
+      fromAddressAssets: [
+        {
+          "name": "Ether",
+          "symbol": "ETH",
+          "address": ETH,
+          "type": "NATIVE"
+        }, {
+          "name": "Dai Stablecoin",
+          "symbol": "DAI",
+          "address": DAI,
+          "type": "20"
+        }, {
+          "name": "DePay",
+          "symbol": "DEPAY",
+          "address": DEPAY,
+          "type": "20"
+        }
+      ],
+      
+      toAddress,
+
+      exchange: 'uniswap_v2',
+      NATIVE_Balance: 0,
+
+      TOKEN_A: DEPAY,
+      TOKEN_A_Decimals: 18,
+      TOKEN_A_Name: 'DePay',
+      TOKEN_A_Symbol: 'DEPAY',
+      TOKEN_A_Amount: amount,
+      TOKEN_A_Balance: 0,
+      
+      TOKEN_B: DAI,
+      TOKEN_B_Decimals: 18,
+      TOKEN_B_Name: 'Dai Stablecoin',
+      TOKEN_B_Symbol: 'DAI',
+      TOKEN_B_Amount: 1.16,
+      TOKEN_B_Balance: 50,
+      TOKEN_B_Allowance: CONSTANTS[blockchain].MAXINT,
+
+      TOKEN_A_TOKEN_B_Pair: CONSTANTS[blockchain].ZERO,
+      TOKEN_B_WRAPPED_Pair: '0xA478c2975Ab1Ea89e8196811F51A7B7Ade33eB11',
+      TOKEN_A_WRAPPED_Pair: '0xEF8cD6Cb5c841A4f02986e8A8ab3cC545d1B8B6d',
+
+      WRAPPED_AmountIn: 0.01,
+      USD_AmountOut: 1.16,
+
+      timeZone: 'Europe/Berlin',
+      stubTimeZone: (timeZone)=> {
+        cy.stub(Intl, 'DateTimeFormat', () => {
+          return { resolvedOptions: ()=>{
+            return { timeZone }
+          }}
+        })
+      },
+
+      currency: 'EUR',
+      currencyToUSD: '0.85'
+    }))
+
+    mockAmountsOut({
+      provider: provider(blockchain),
+      blockchain,
+      exchange,
+      amountInBN: '1176470588235294200',
+      path: [DAI, WETH, DEPAY],
+      amountsOut: [
+        '1176470588235294200',
+        WRAPPED_AmountInBN,
+        TOKEN_A_AmountBN
+      ]
+    })
+  })
+  
+  describe('prevents payments that would lose to much value', () => {
+
+    it('shows a warning and prevents payment', ()=> {
+      let fromAddress = accounts[0]
+      mockAmountsOut({
+        provider: provider(blockchain),
+        blockchain,
+        exchange,
+        amountInBN: '11764705882352942000',
+        path: [DAI, WETH, DEPAY],
+        amountsOut: [
+          '11764705882352942000',
+          WRAPPED_AmountInBN.mul(10),
+          TOKEN_A_AmountBN.mul(10)
+        ]
+      })
+      mock({
+        provider: provider(blockchain),
+        blockchain,
+        call: {
+          to: exchange.contracts.router.address,
+          api: exchange.contracts.router.api,
+          method: 'getAmountsIn',
+          params: [ethers.utils.parseUnits('18', 18), [DAI, WETH, DEPAY]],
+          return: [ethers.utils.parseUnits('18', 18), ethers.utils.parseUnits('0.05', 18), ethers.utils.parseUnits('11.6', 18)]
+        }
+      })
+      mockAmountsOut({
+        provider: provider(blockchain),
+        blockchain,
+        exchange,
+        amountInBN: ethers.utils.parseUnits('18', 18),
+        path: [DEPAY, WETH, DAI],
+        amountsOut: [
+          ethers.utils.parseUnits('18', 18),
+          ethers.utils.parseUnits('0.05', 18),
+          ethers.utils.parseUnits('11.6', 18)
+        ]
+      })
+
+      cy.visit('cypress/test.html').then((contentWindow) => {
+        cy.document().then((document)=>{
+          DePayWidgets.Payment({ ...defaultArguments, document })
+          cy.get('.ReactShadowDOMOutsideContainer').shadow().find('.Card[title="Change amount"]').click()
+          cy.get('.ReactShadowDOMOutsideContainer').shadow().find('input').type('{selectall}')
+          cy.get('.ReactShadowDOMOutsideContainer').shadow().find('input').type('10', { force: true })
+          cy.get('.ReactShadowDOMOutsideContainer').shadow().contains('.ButtonPrimary', 'Done').click()
+          cy.get('.ReactShadowDOMOutsideContainer').shadow().contains('.Alert', "Payment token would lose 36% of it's value!").should('exist')
+          cy.get('.ReactShadowDOMOutsideContainer').shadow().contains('.ButtonPrimary.disabled').should('exist')
+        })
+      })
+    })
+  })
+})
+

--- a/cypress/integration/Sale/amount.js
+++ b/cypress/integration/Sale/amount.js
@@ -369,7 +369,7 @@ describe('change Purchase amount', () => {
           api: exchange.contracts.router.api,
           method: 'getAmountsIn',
           params: [ethers.utils.parseUnits('18', 18), [DAI, WETH, DEPAY]],
-          return: [ethers.utils.parseUnits('18', 18), ethers.utils.parseUnits('0.05', 18), ethers.utils.parseUnits('11.6', 18)]
+          return: [ethers.utils.parseUnits('18', 18), ethers.utils.parseUnits('0.05', 18), ethers.utils.parseUnits('18', 18)]
         }
       })
       mockAmountsOut({
@@ -381,7 +381,7 @@ describe('change Purchase amount', () => {
         amountsOut: [
           ethers.utils.parseUnits('18', 18),
           ethers.utils.parseUnits('0.05', 18),
-          ethers.utils.parseUnits('11.6', 18)
+          ethers.utils.parseUnits('18', 18)
         ]
       })
 

--- a/dev.html
+++ b/dev.html
@@ -206,6 +206,29 @@
       <div class="row">
       <div class="col-4"></div>
       <div class="col-4">
+        <h2 class="pt-5">Payment with Parsiq</h2>
+        <button id="payWithParsiq" class="btn-lg mt-2">Pay with Parsiq</button>
+        <script>
+          var button = document.getElementById("payWithParsiq");
+          button.addEventListener("click",function(e){
+            DePayWidgets.Payment({
+              accept: [{
+                blockchain: 'bsc',
+                amount: 30,
+                token: '0xd21d29b38374528675c34936bf7d5dd693d2a577',
+                receiver: '0x08B277154218CCF3380CAE48d630DA13462E3950'
+              }]
+            });
+          });
+        </script>
+      </div>
+      <div class="col-4"></div>
+    </div><!-- Payment -->
+
+    <div class="container pb-4"><!-- Payment -->
+      <div class="row">
+      <div class="col-4"></div>
+      <div class="col-4">
         <h2 class="pt-5">Payment with tracking</h2>
         <button id="payWithTracking" class="btn-lg mt-2">Pay with tracking</button>
         <script>
@@ -218,6 +241,63 @@
                 token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
                 receiver: '0x08B277154218CCF3380CAE48d630DA13462E3950'
               }],
+              track: {
+                endpoint: '/track'
+              }
+            });
+          });
+        </script>
+      </div>
+      <div class="col-4"></div>
+    </div><!-- Payment -->
+
+    <div class="container pb-4"><!-- Payment -->
+      <div class="row">
+      <div class="col-4"></div>
+      <div class="col-4">
+        <h2 class="pt-5">Payment with fee</h2>
+        <button id="payWithFee" class="btn-lg mt-2">Pay with fee</button>
+        <script>
+          var button = document.getElementById("payWithFee");
+          button.addEventListener("click",function(e){
+            DePayWidgets.Payment({
+              accept: [{
+                blockchain: 'bsc',
+                amount: 0.0001,
+                token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+                receiver: '0x08B277154218CCF3380CAE48d630DA13462E3950'
+              }],
+              fee: {
+                amount: '1%',
+                receiver: '0x317D875cA3B9f8d14f960486C0d1D1913be74e90'
+              }
+            });
+          });
+        </script>
+      </div>
+      <div class="col-4"></div>
+    </div><!-- Payment -->
+
+    <div class="container pb-4"><!-- Payment -->
+      <div class="row">
+      <div class="col-4"></div>
+      <div class="col-4">
+        <h2 class="pt-5">Payment with fee and tracking</h2>
+        <button id="payWithFeeAndTracking" class="btn-lg mt-2">Pay with fee and tracking</button>
+        <script>
+          var button = document.getElementById("payWithFeeAndTracking");
+          button.addEventListener("click",function(e){
+            DePayWidgets.Payment({
+              accept: [{
+                blockchain: 'bsc',
+                amount: 0.0001,
+                token: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+                receiver: '0x08B277154218CCF3380CAE48d630DA13462E3950'
+              }],
+              fee: {
+                amount: '1%',
+                receiver: '0x317D875cA3B9f8d14f960486C0d1D1913be74e90'
+              },
               track: {
                 endpoint: '/track'
               }

--- a/dist/esm/index.bundle.js
+++ b/dist/esm/index.bundle.js
@@ -68019,15 +68019,20 @@ var PaymentValueProvider = (function (props) {
       paymentValue = _useState2[0],
       setPaymentValue = _useState2[1];
 
+  var _useState3 = react.useState(),
+      _useState4 = _slicedToArray(_useState3, 2),
+      paymentValueLoss = _useState4[0],
+      setPaymentValueLoss = _useState4[1];
+
   var _useContext5 = react.useContext(ConfigurationContext),
       currency = _useContext5.currency;
 
-  var _useState3 = react.useState(0),
-      _useState4 = _slicedToArray(_useState3, 2),
-      reloadCount = _useState4[0],
-      setReloadCount = _useState4[1];
+  var _useState5 = react.useState(0),
+      _useState6 = _slicedToArray(_useState5, 2),
+      reloadCount = _useState6[0],
+      setReloadCount = _useState6[1];
 
-  var getToTokenLocalValue = function getToTokenLocalValue(_ref) {
+  var updatePaymentValue = function updatePaymentValue(_ref) {
     var updatable = _ref.updatable,
         payment = _ref.payment;
 
@@ -68042,29 +68047,51 @@ var PaymentValueProvider = (function (props) {
       amountIn: payment.route.toAmount,
       fromAddress: account,
       toAddress: account
-    }), new Token({
+    }), !payment.route.directTransfer ? route$8({
+      blockchain: payment.route.blockchain,
+      tokenIn: payment.route.toToken.address,
+      tokenOut: payment.route.fromToken.address,
+      amountIn: payment.route.toAmount,
+      fromAddress: account,
+      toAddress: account
+    }) : Promise.resolve([]), new Token({
       blockchain: payment.route.blockchain,
       address: CONSTANTS$2[payment.route.blockchain].USD
     }).decimals()]).then(function (_ref2) {
-      var _ref3 = _slicedToArray(_ref2, 2),
-          USDExchangeRoutes = _ref3[0],
-          USDDecimals = _ref3[1];
+      var _ref3 = _slicedToArray(_ref2, 3),
+          toTokenUSDExchangeRoutes = _ref3[0],
+          reverseRoutes = _ref3[1],
+          USDDecimals = _ref3[2];
 
-      var USDRoute = USDExchangeRoutes[0];
-      var USDAmount;
+      var toTokenUSDRoute = toTokenUSDExchangeRoutes[0];
+      var reverseRoute = reverseRoutes[0];
+
+      if (reverseRoute) {
+        var reverseAmountOutBN = BigNumber$4.from(reverseRoute.amountOut);
+        var paymentAmountInBN = BigNumber$4.from(payment.route.fromAmount);
+        var divPercent = 100 - reverseAmountOutBN.mul(BigNumber$4.from('100')).div(paymentAmountInBN).abs().toString();
+
+        if (divPercent >= 5) {
+          setPaymentValueLoss(divPercent);
+        } else {
+          setPaymentValueLoss(null);
+        }
+      }
+
+      var toTokenUSDAmount;
 
       if (payment.route.toToken.address.toLowerCase() == CONSTANTS$2[payment.route.blockchain].USD.toLowerCase()) {
-        USDAmount = payment.route.toAmount.toString();
-      } else if (USDRoute == undefined) {
+        toTokenUSDAmount = payment.route.toAmount.toString();
+      } else if (toTokenUSDRoute == undefined) {
         setPaymentValue('');
         return;
       } else {
-        USDAmount = USDRoute.amountOut.toString();
+        toTokenUSDAmount = toTokenUSDRoute.amountOut.toString();
       }
 
-      var USDValue = formatUnits(USDAmount, USDDecimals);
+      var toTokenUSDValue = formatUnits(toTokenUSDAmount, USDDecimals);
       Currency.fromUSD({
-        amount: USDValue,
+        amount: toTokenUSDValue,
         code: currency,
         apiKey: apiKey
       }).then(setPaymentValue)["catch"](setError);
@@ -68073,7 +68100,7 @@ var PaymentValueProvider = (function (props) {
 
   react.useEffect(function () {
     if (account && payment) {
-      getToTokenLocalValue({
+      updatePaymentValue({
         updatable: updatable,
         payment: payment
       });
@@ -68082,7 +68109,7 @@ var PaymentValueProvider = (function (props) {
   react.useEffect(function () {
     var timeout = setTimeout(function () {
       setReloadCount(reloadCount + 1);
-      getToTokenLocalValue({
+      updatePaymentValue({
         updatable: updatable
       });
     }, 15000);
@@ -68092,7 +68119,8 @@ var PaymentValueProvider = (function (props) {
   }, [reloadCount, updatable]);
   return /*#__PURE__*/react.createElement(PaymentValueContext.Provider, {
     value: {
-      paymentValue: paymentValue
+      paymentValue: paymentValue,
+      paymentValueLoss: paymentValueLoss
     }
   }, props.children);
 });
@@ -70248,7 +70276,8 @@ var Footer = (function () {
       approvalTransaction = _useContext4.approvalTransaction;
 
   var _useContext5 = react.useContext(PaymentValueContext),
-      paymentValue = _useContext5.paymentValue;
+      paymentValue = _useContext5.paymentValue,
+      paymentValueLoss = _useContext5.paymentValueLoss;
 
   var _useContext6 = react.useContext(NavigateStackContext);
       _useContext6.navigate;
@@ -70394,7 +70423,16 @@ var Footer = (function () {
       displayedAmount = "".concat(payment.symbol, " ").concat(payment.amount);
     }
 
-    if ((paymentState == 'initialized' || paymentState == 'approving') && payment.route) {
+    if (paymentValueLoss) {
+      return /*#__PURE__*/react.createElement("div", null, /*#__PURE__*/react.createElement("div", {
+        className: "PaddingBottomXS"
+      }, /*#__PURE__*/react.createElement("div", {
+        className: "Alert"
+      }, /*#__PURE__*/react.createElement("strong", null, "Payment token would lose ", paymentValueLoss, "% of it's value!"))), /*#__PURE__*/react.createElement("button", {
+        className: "ButtonPrimary disabled",
+        onClick: function onClick() {}
+      }, "Pay ", displayedAmount));
+    } else if ((paymentState == 'initialized' || paymentState == 'approving') && payment.route) {
       return /*#__PURE__*/react.createElement("button", {
         className: ["ButtonPrimary", payment.route.approvalRequired && !payment.route.directTransfer ? 'disabled' : ''].join(' '),
         onClick: function onClick() {

--- a/dist/umd/index.bundle.js
+++ b/dist/umd/index.bundle.js
@@ -68025,15 +68025,20 @@
         paymentValue = _useState2[0],
         setPaymentValue = _useState2[1];
 
+    var _useState3 = react.useState(),
+        _useState4 = _slicedToArray(_useState3, 2),
+        paymentValueLoss = _useState4[0],
+        setPaymentValueLoss = _useState4[1];
+
     var _useContext5 = react.useContext(ConfigurationContext),
         currency = _useContext5.currency;
 
-    var _useState3 = react.useState(0),
-        _useState4 = _slicedToArray(_useState3, 2),
-        reloadCount = _useState4[0],
-        setReloadCount = _useState4[1];
+    var _useState5 = react.useState(0),
+        _useState6 = _slicedToArray(_useState5, 2),
+        reloadCount = _useState6[0],
+        setReloadCount = _useState6[1];
 
-    var getToTokenLocalValue = function getToTokenLocalValue(_ref) {
+    var updatePaymentValue = function updatePaymentValue(_ref) {
       var updatable = _ref.updatable,
           payment = _ref.payment;
 
@@ -68048,29 +68053,51 @@
         amountIn: payment.route.toAmount,
         fromAddress: account,
         toAddress: account
-      }), new Token({
+      }), !payment.route.directTransfer ? route$8({
+        blockchain: payment.route.blockchain,
+        tokenIn: payment.route.toToken.address,
+        tokenOut: payment.route.fromToken.address,
+        amountIn: payment.route.toAmount,
+        fromAddress: account,
+        toAddress: account
+      }) : Promise.resolve([]), new Token({
         blockchain: payment.route.blockchain,
         address: CONSTANTS$2[payment.route.blockchain].USD
       }).decimals()]).then(function (_ref2) {
-        var _ref3 = _slicedToArray(_ref2, 2),
-            USDExchangeRoutes = _ref3[0],
-            USDDecimals = _ref3[1];
+        var _ref3 = _slicedToArray(_ref2, 3),
+            toTokenUSDExchangeRoutes = _ref3[0],
+            reverseRoutes = _ref3[1],
+            USDDecimals = _ref3[2];
 
-        var USDRoute = USDExchangeRoutes[0];
-        var USDAmount;
+        var toTokenUSDRoute = toTokenUSDExchangeRoutes[0];
+        var reverseRoute = reverseRoutes[0];
+
+        if (reverseRoute) {
+          var reverseAmountOutBN = BigNumber$4.from(reverseRoute.amountOut);
+          var paymentAmountInBN = BigNumber$4.from(payment.route.fromAmount);
+          var divPercent = 100 - reverseAmountOutBN.mul(BigNumber$4.from('100')).div(paymentAmountInBN).abs().toString();
+
+          if (divPercent >= 5) {
+            setPaymentValueLoss(divPercent);
+          } else {
+            setPaymentValueLoss(null);
+          }
+        }
+
+        var toTokenUSDAmount;
 
         if (payment.route.toToken.address.toLowerCase() == CONSTANTS$2[payment.route.blockchain].USD.toLowerCase()) {
-          USDAmount = payment.route.toAmount.toString();
-        } else if (USDRoute == undefined) {
+          toTokenUSDAmount = payment.route.toAmount.toString();
+        } else if (toTokenUSDRoute == undefined) {
           setPaymentValue('');
           return;
         } else {
-          USDAmount = USDRoute.amountOut.toString();
+          toTokenUSDAmount = toTokenUSDRoute.amountOut.toString();
         }
 
-        var USDValue = formatUnits(USDAmount, USDDecimals);
+        var toTokenUSDValue = formatUnits(toTokenUSDAmount, USDDecimals);
         Currency.fromUSD({
-          amount: USDValue,
+          amount: toTokenUSDValue,
           code: currency,
           apiKey: apiKey
         }).then(setPaymentValue)["catch"](setError);
@@ -68079,7 +68106,7 @@
 
     react.useEffect(function () {
       if (account && payment) {
-        getToTokenLocalValue({
+        updatePaymentValue({
           updatable: updatable,
           payment: payment
         });
@@ -68088,7 +68115,7 @@
     react.useEffect(function () {
       var timeout = setTimeout(function () {
         setReloadCount(reloadCount + 1);
-        getToTokenLocalValue({
+        updatePaymentValue({
           updatable: updatable
         });
       }, 15000);
@@ -68098,7 +68125,8 @@
     }, [reloadCount, updatable]);
     return /*#__PURE__*/react.createElement(PaymentValueContext.Provider, {
       value: {
-        paymentValue: paymentValue
+        paymentValue: paymentValue,
+        paymentValueLoss: paymentValueLoss
       }
     }, props.children);
   });
@@ -70254,7 +70282,8 @@
         approvalTransaction = _useContext4.approvalTransaction;
 
     var _useContext5 = react.useContext(PaymentValueContext),
-        paymentValue = _useContext5.paymentValue;
+        paymentValue = _useContext5.paymentValue,
+        paymentValueLoss = _useContext5.paymentValueLoss;
 
     var _useContext6 = react.useContext(NavigateStackContext);
         _useContext6.navigate;
@@ -70400,7 +70429,16 @@
         displayedAmount = "".concat(payment.symbol, " ").concat(payment.amount);
       }
 
-      if ((paymentState == 'initialized' || paymentState == 'approving') && payment.route) {
+      if (paymentValueLoss) {
+        return /*#__PURE__*/react.createElement("div", null, /*#__PURE__*/react.createElement("div", {
+          className: "PaddingBottomXS"
+        }, /*#__PURE__*/react.createElement("div", {
+          className: "Alert"
+        }, /*#__PURE__*/react.createElement("strong", null, "Payment token would lose ", paymentValueLoss, "% of it's value!"))), /*#__PURE__*/react.createElement("button", {
+          className: "ButtonPrimary disabled",
+          onClick: function onClick() {}
+        }, "Pay ", displayedAmount));
+      } else if ((paymentState == 'initialized' || paymentState == 'approving') && payment.route) {
         return /*#__PURE__*/react.createElement("button", {
           className: ["ButtonPrimary", payment.route.approvalRequired && !payment.route.directTransfer ? 'disabled' : ''].join(' '),
           onClick: function onClick() {

--- a/dist/umd/index.js
+++ b/dist/umd/index.js
@@ -2764,15 +2764,20 @@
         paymentValue = _useState2[0],
         setPaymentValue = _useState2[1];
 
+    var _useState3 = React.useState(),
+        _useState4 = _slicedToArray(_useState3, 2),
+        paymentValueLoss = _useState4[0],
+        setPaymentValueLoss = _useState4[1];
+
     var _useContext5 = React.useContext(ConfigurationContext),
         currency = _useContext5.currency;
 
-    var _useState3 = React.useState(0),
-        _useState4 = _slicedToArray(_useState3, 2),
-        reloadCount = _useState4[0],
-        setReloadCount = _useState4[1];
+    var _useState5 = React.useState(0),
+        _useState6 = _slicedToArray(_useState5, 2),
+        reloadCount = _useState6[0],
+        setReloadCount = _useState6[1];
 
-    var getToTokenLocalValue = function getToTokenLocalValue(_ref) {
+    var updatePaymentValue = function updatePaymentValue(_ref) {
       var updatable = _ref.updatable,
           payment = _ref.payment;
 
@@ -2787,29 +2792,51 @@
         amountIn: payment.route.toAmount,
         fromAddress: account,
         toAddress: account
-      }), new web3Tokens.Token({
+      }), !payment.route.directTransfer ? web3Exchanges.route({
+        blockchain: payment.route.blockchain,
+        tokenIn: payment.route.toToken.address,
+        tokenOut: payment.route.fromToken.address,
+        amountIn: payment.route.toAmount,
+        fromAddress: account,
+        toAddress: account
+      }) : Promise.resolve([]), new web3Tokens.Token({
         blockchain: payment.route.blockchain,
         address: web3Constants.CONSTANTS[payment.route.blockchain].USD
       }).decimals()]).then(function (_ref2) {
-        var _ref3 = _slicedToArray(_ref2, 2),
-            USDExchangeRoutes = _ref3[0],
-            USDDecimals = _ref3[1];
+        var _ref3 = _slicedToArray(_ref2, 3),
+            toTokenUSDExchangeRoutes = _ref3[0],
+            reverseRoutes = _ref3[1],
+            USDDecimals = _ref3[2];
 
-        var USDRoute = USDExchangeRoutes[0];
-        var USDAmount;
+        var toTokenUSDRoute = toTokenUSDExchangeRoutes[0];
+        var reverseRoute = reverseRoutes[0];
+
+        if (reverseRoute) {
+          var reverseAmountOutBN = ethers.ethers.BigNumber.from(reverseRoute.amountOut);
+          var paymentAmountInBN = ethers.ethers.BigNumber.from(payment.route.fromAmount);
+          var divPercent = 100 - reverseAmountOutBN.mul(ethers.ethers.BigNumber.from('100')).div(paymentAmountInBN).abs().toString();
+
+          if (divPercent >= 5) {
+            setPaymentValueLoss(divPercent);
+          } else {
+            setPaymentValueLoss(null);
+          }
+        }
+
+        var toTokenUSDAmount;
 
         if (payment.route.toToken.address.toLowerCase() == web3Constants.CONSTANTS[payment.route.blockchain].USD.toLowerCase()) {
-          USDAmount = payment.route.toAmount.toString();
-        } else if (USDRoute == undefined) {
+          toTokenUSDAmount = payment.route.toAmount.toString();
+        } else if (toTokenUSDRoute == undefined) {
           setPaymentValue('');
           return;
         } else {
-          USDAmount = USDRoute.amountOut.toString();
+          toTokenUSDAmount = toTokenUSDRoute.amountOut.toString();
         }
 
-        var USDValue = ethers.ethers.utils.formatUnits(USDAmount, USDDecimals);
+        var toTokenUSDValue = ethers.ethers.utils.formatUnits(toTokenUSDAmount, USDDecimals);
         localCurrency.Currency.fromUSD({
-          amount: USDValue,
+          amount: toTokenUSDValue,
           code: currency,
           apiKey: apiKey
         }).then(setPaymentValue)["catch"](setError);
@@ -2818,7 +2845,7 @@
 
     React.useEffect(function () {
       if (account && payment) {
-        getToTokenLocalValue({
+        updatePaymentValue({
           updatable: updatable,
           payment: payment
         });
@@ -2827,7 +2854,7 @@
     React.useEffect(function () {
       var timeout = setTimeout(function () {
         setReloadCount(reloadCount + 1);
-        getToTokenLocalValue({
+        updatePaymentValue({
           updatable: updatable
         });
       }, 15000);
@@ -2837,7 +2864,8 @@
     }, [reloadCount, updatable]);
     return /*#__PURE__*/React__default['default'].createElement(PaymentValueContext.Provider, {
       value: {
-        paymentValue: paymentValue
+        paymentValue: paymentValue,
+        paymentValueLoss: paymentValueLoss
       }
     }, props.children);
   });
@@ -3271,7 +3299,8 @@
         approvalTransaction = _useContext4.approvalTransaction;
 
     var _useContext5 = React.useContext(PaymentValueContext),
-        paymentValue = _useContext5.paymentValue;
+        paymentValue = _useContext5.paymentValue,
+        paymentValueLoss = _useContext5.paymentValueLoss;
 
     var _useContext6 = React.useContext(reactDialogStack.NavigateStackContext);
         _useContext6.navigate;
@@ -3417,7 +3446,16 @@
         displayedAmount = "".concat(payment.symbol, " ").concat(payment.amount);
       }
 
-      if ((paymentState == 'initialized' || paymentState == 'approving') && payment.route) {
+      if (paymentValueLoss) {
+        return /*#__PURE__*/React__default['default'].createElement("div", null, /*#__PURE__*/React__default['default'].createElement("div", {
+          className: "PaddingBottomXS"
+        }, /*#__PURE__*/React__default['default'].createElement("div", {
+          className: "Alert"
+        }, /*#__PURE__*/React__default['default'].createElement("strong", null, "Payment token would lose ", paymentValueLoss, "% of it's value!"))), /*#__PURE__*/React__default['default'].createElement("button", {
+          className: "ButtonPrimary disabled",
+          onClick: function onClick() {}
+        }, "Pay ", displayedAmount));
+      } else if ((paymentState == 'initialized' || paymentState == 'approving') && payment.route) {
         return /*#__PURE__*/React__default['default'].createElement("button", {
           className: ["ButtonPrimary", payment.route.approvalRequired && !payment.route.directTransfer ? 'disabled' : ''].join(' '),
           onClick: function onClick() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@depay/widgets",
   "moduleName": "DePayWidgets",
-  "version": "6.14.0",
+  "version": "6.15.0",
   "description": "Web3 Payments with any token. DePay simplifies and improves Web3 Payments with the power of DeFi. Accept any token with on-the-fly conversion.",
   "main": "./dist/umd/index.js",
   "module": "./dist/esm/index.js",

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -17,7 +17,7 @@ export default ()=>{
   const { amount, amountsMissing } = useContext(ChangableAmountContext)
   const { tracking, release, forwardTo, trackingFailed } = useContext(PaymentTrackingContext)
   const { payment, paymentState, pay, transaction, approve, approvalTransaction } = useContext(PaymentContext)
-  const { paymentValue } = useContext(PaymentValueContext)
+  const { paymentValue, paymentValueLoss } = useContext(PaymentValueContext)
   const { navigate } = useContext(NavigateStackContext)
   const { close } = useContext(ClosableContext)
 
@@ -162,7 +162,20 @@ export default ()=>{
       displayedAmount = `${payment.symbol} ${payment.amount}`
     }
 
-    if((paymentState == 'initialized' || paymentState == 'approving') && payment.route) {
+    if(paymentValueLoss){
+      return(
+        <div>
+          <div className="PaddingBottomXS">
+            <div className="Alert">
+              <strong>Payment token would lose {paymentValueLoss}% of it's value!</strong>
+            </div>
+          </div>
+          <button className={"ButtonPrimary disabled"} onClick={()=>{}}>
+            Pay { displayedAmount }
+          </button>
+        </div>
+      )
+    } else if((paymentState == 'initialized' || paymentState == 'approving') && payment.route) {
       return(
         <button 
           className={["ButtonPrimary", (payment.route.approvalRequired && !payment.route.directTransfer ? 'disabled': '')].join(' ')}


### PR DESCRIPTION
In cases where users configure toTokens that have pairs with insufficient liquidity swapping will result in immediate losses from a payment value perspectiv. e.g. paying 50$ where the liquidity of the dex pair is 50$.

In order to prevent people selecting those payment routes, the following safe guard will be added:
<img width="519" alt="Screenshot 2022-02-04 at 08 50 08" src="https://user-images.githubusercontent.com/851393/152491644-72bde6e9-0f69-42f8-b2fa-b7ce235f7acc.png">

